### PR TITLE
Change to processScriptsEvent

### DIFF
--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -122,7 +122,7 @@ public:
         ThiscallEvent <AddressList<0x602BE7, H_CALL>, PRIORITY_AFTER, ArgPick2N<CPad*, 0, int, 1>, void(CPad*, int)> addToPCCheatString;
 #endif
 #ifdef GTASA
-        plugin::Events::gameProcessEvent += [] {
+        plugin::Events::processScriptsEvent += [] {
 #else
         addToPCCheatString += [](CPad* pad, int) {
 #endif


### PR DESCRIPTION
The mod was not working here. Normally we use processScriptsEvent instead, because gameProcessEvent runs even during paused game and does not work in SAMP. And in my case, some mod caused conflict that made it not work on gameProcessEvent (I didn't search which mod).